### PR TITLE
Memory leak

### DIFF
--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -39,6 +39,13 @@ Adafruit_WS2801::Adafruit_WS2801(void) {
   updatePins(); // Must assume hardware SPI until pins are set
 }
 
+// Release memory (as needed):
+Adafruit_WS2801::~Adafruit_WS2801(void) {
+  if (pixels != NULL) {
+    free(pixels);
+  }
+}
+
 // Activate hard/soft SPI as appropriate:
 void Adafruit_WS2801::begin(void) {
   if(hardwareSPI == true) {

--- a/Adafruit_WS2801.h
+++ b/Adafruit_WS2801.h
@@ -23,6 +23,8 @@ class Adafruit_WS2801 {
   Adafruit_WS2801(uint16_t n, uint8_t order=WS2801_RGB);
   // Empty constructor; init pins/strand length/data order later:
   Adafruit_WS2801();
+  // Release memory (as needed):
+  ~Adafruit_WS2801();
 
   void
     begin(void),


### PR DESCRIPTION
The `Adafruit_WS2801` class does not free allocated memory on destruction.

Test case:

``` c++
#include <SPI.h>
#include <Adafruit_WS201.h>

void setup() {
  Serial.begin(115200);
}

void loop() {
  Adafruit_WS2801 strip(25, 2, 3);
  Serial.println(strip.numPixels()); // should never be 0
  delay(100);
}
```
