### PR TITLE
Adafruit_WS2801.getPixelColor() suffers overflow

### DIFF
--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -187,7 +187,7 @@ uint32_t Adafruit_WS2801::getPixelColor(uint16_t n) {
     // types.  For compatibility with existing code, 'packed' RGB
     // values passed in or out are always 0xRRGGBB order.
     return (rgb_order == WS2801_RGB) ?
-      ((uint32_t)pixels[ofs] << 16) | (pixels[ofs + 1] <<  8) | pixels[ofs + 2] :
+      ((uint32_t)pixels[ofs] << 16) | ((uint16_t) pixels[ofs + 1] <<  8) | pixels[ofs + 2] :
       (pixels[ofs] <<  8) | ((uint32_t)pixels[ofs + 1] << 16) | pixels[ofs + 2];
   }
 


### PR DESCRIPTION
The getPixelColor() method was not round-tripping all pixel values correctly.  I added a cast to unsigned, so the bit shift of the middle byte would not overflow.

Thank you for an excellent library!
