### PR TITLE
Color method port from neopixel

### DIFF
--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -273,6 +273,12 @@ void Adafruit_WS2801::setPixelColor(uint16_t x, uint16_t y, uint32_t c) {
   setPixelColor(offset, c);
 }
 
+// Convert separate R,G,B into packed 32-bit RGB color.
+// Packed format is always RGB, regardless of LED strand color order.
+uint32_t Adafruit_WS2801::Color(uint8_t r, uint8_t g, uint8_t b) {
+  return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
+}
+
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
 uint32_t Adafruit_WS2801::getPixelColor(uint16_t n) {
   if(n < numLEDs) {

--- a/Adafruit_WS2801.h
+++ b/Adafruit_WS2801.h
@@ -45,6 +45,8 @@ class Adafruit_WS2801 {
     numPixels(void);
   uint32_t
     getPixelColor(uint16_t n);
+  static uint32_t
+    Color(uint8_t r, uint8_t g, uint8_t b);
 
  private:
 


### PR DESCRIPTION
I needed the Color() method from the Adafruit NeoPixel library to get backported to the WS2801 library so that I could maintain drop-in compatibility (in my sketches) between the NeoPixel and the WS2801 library.  (allows for WS2812b analogs to be used for significantly larger WS2801 projects)