### PR TITLE
Prevent segfaults by implementing the rule of three 

### DIFF
--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -75,7 +75,7 @@ Adafruit_WS2801::Adafruit_WS2801(uint16_t w, uint16_t h, uint8_t dpin, uint8_t c
 // Allocate 3 bytes per pixel, init to RGB 'off' state:
 void Adafruit_WS2801::alloc(uint16_t n) {
   begun   = false;
-  numLEDs = ((pixels = (uint8_t *)calloc(n, 3)) != NULL) ? n : 0;
+  numLEDs = ((pixels = (uint8_t *)calloc(n * 3, sizeof(uint8_t))) != NULL) ? n : 0;
 }
 
 // via Michael Vogt/neophob: empty constructor is used when strand length
@@ -173,7 +173,7 @@ uint16_t Adafruit_WS2801::numPixels(void) {
 void Adafruit_WS2801::updateLength(uint16_t n) {
   if(pixels != NULL) free(pixels); // Free existing data (if any)
   // Allocate new data -- note: ALL PIXELS ARE CLEARED
-  numLEDs = ((pixels = (uint8_t *)calloc(n, 3)) != NULL) ? n : 0;
+  numLEDs = ((pixels = (uint8_t *)calloc(n * 3, sizeof(uint8_t))) != NULL) ? n : 0;
   // 'begun' state does not change -- pins retain prior modes
 }
 

--- a/Adafruit_WS2801.h
+++ b/Adafruit_WS2801.h
@@ -25,10 +25,15 @@ class Adafruit_WS2801 {
   Adafruit_WS2801(uint16_t x, uint16_t y, uint8_t dpin, uint8_t cpin, uint8_t order=WS2801_RGB);
   // Use SPI hardware; specific pins only:
   Adafruit_WS2801(uint16_t n, uint8_t order=WS2801_RGB);
+  // Copy constructor; without it, pointers are copied blindly
+  Adafruit_WS2801(const Adafruit_WS2801 &orig);
   // Empty constructor; init pins/strand length/data order later:
   Adafruit_WS2801();
   // Release memory (as needed):
   ~Adafruit_WS2801();
+
+  // assignment operator
+  Adafruit_WS2801& operator=(const Adafruit_WS2801& orig);
 
   void
     begin(void),
@@ -63,7 +68,10 @@ class Adafruit_WS2801 {
     *clkport  , *dataport;   // Clock & data PORT registers
 #endif
   void
-    alloc(uint16_t n),
+    copy(const Adafruit_WS2801 &orig),
+    setPixels(uint16_t n),  // allocate memory
+    alloc(uint16_t n),      // allocate memory and set flags
+    dealloc(),              // deallocate memory
     startSPI(void);
   boolean
     hardwareSPI, // If 'true', using hardware SPI


### PR DESCRIPTION
## Scope

This change includes the following:
* when using `calloc`, don't assume that `uint8_t` is 1 byte when you can just do `sizeof(unit8_t)`
* centralize memory `alloc`ation and `free`ing into standalone functions
* add a copy constructor and assignment operator to `class Adafruit_WS2801` to implement the [rule of three [Wikipedia]](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming))

There are no functional changes.


## Motivation

I'm using [arduino_ci](https://github.com/ianfixes/arduino_ci) to test a library that includes WS2801 as a dependency.  I got this strange error:

```
==49292==ERROR: AddressSanitizer: attempting double-free on 0x603000000280 in thread T0:
    #0 0x10bd62fdd in wrap_free (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x56fdd)
    #1 0x10bcd5be3 in Adafruit_WS2801::dealloc() Adafruit_WS2801.cpp:84
    #2 0x10bcd6048 in Adafruit_WS2801::~Adafruit_WS2801() Adafruit_WS2801.cpp:132
    #3 0x10bcd6058 in Adafruit_WS2801::~Adafruit_WS2801() Adafruit_WS2801.cpp:131
    #4 0x10bcd3a98 in Strip::~Strip() Strip.h:9
    #5 0x10bcd3a88 in Strip::~Strip() Strip.h:9
    #6 0x10bcd7dfb in test_set_strip_values::task() strip.cpp:31
    #7 0x10bcd9030 in Test::test() ArduinoUnitTests.h:165
    #8 0x10bcd8704 in Test::run(Test::ReporterTAP*) ArduinoUnitTests.h:137
    #9 0x10bcd82a9 in Test::run_and_report(int, char**) ArduinoUnitTests.h:155
    #10 0x10bcd81e8 in main strip.cpp:33
    #11 0x7fff6c6c2014 in start (libdyld.dylib:x86_64+0x1014)
```

This is caused because the unit test triggers a copy/assignment of the `Adafruit_WS2801` class; with no copy constructor explicitly provided, a shallow copy is made, **which includes the `pixels` pointer, meaning that 2 objects are now sharing memory**.  The trouble happens when the first of those objects drops out of scope and deallocates.

This will probably never happen when run on Arduino, but for unit testing purposes it produces a very unexpected result.


## Testing

As stated above, I've tested this change via my CI scripts.  I will link to the CI job when I push those other changes.
