### PR TITLE
Add clear method for WS2801 string.

### DIFF
--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -295,10 +295,9 @@ void Adafruit_WS2801::setPixelColor(uint16_t x, uint16_t y, uint32_t c) {
 
 // Clear all pixels
 void Adafruit_WS2801::clear() {
-    if (pixels != NULL)
-    {
-        memset(pixels, 0, numLEDs*3);
-    }
+  if (pixels != NULL) {
+    memset(pixels, 0, numLEDs*3);
+  }
 }
 
 // Query color from previously-set pixel (returns packed 32-bit RGB value)

--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -296,7 +296,7 @@ void Adafruit_WS2801::setPixelColor(uint16_t x, uint16_t y, uint32_t c) {
 // Clear all pixels
 void Adafruit_WS2801::clear() {
   if (pixels != NULL) {
-    memset(pixels, 0, numLEDs*3);
+    memset(pixels, 0, numLEDs * 3);
   }
 }
 

--- a/Adafruit_WS2801.cpp
+++ b/Adafruit_WS2801.cpp
@@ -293,6 +293,14 @@ void Adafruit_WS2801::setPixelColor(uint16_t x, uint16_t y, uint32_t c) {
   setPixelColor(offset, c);
 }
 
+// Clear all pixels
+void Adafruit_WS2801::clear() {
+    if (pixels != NULL)
+    {
+        memset(pixels, 0, numLEDs*3);
+    }
+}
+
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
 uint32_t Adafruit_WS2801::getPixelColor(uint16_t n) {
   if (n < numLEDs) {

--- a/Adafruit_WS2801.h
+++ b/Adafruit_WS2801.h
@@ -101,7 +101,11 @@ public:
      */
     setPixelColor(uint16_t x, uint16_t y, uint32_t c),
     /*!
-     * @brief Change pin assignment post-constructor, using arbitrary pins 
+     * @brief Clear the entire string
+     */
+    clear(),
+    /*!
+     * @brief Change pin assignment post-constructor, using arbitrary pins
      * @param dpin Data pin
      * @param cpin Clock pin
      */


### PR DESCRIPTION
Scope: Addition of new `clear` method. Sets the entire internal RAM array to 0 using the `memset` function, only if the `pixels` member is not null.

Limitations: None expected/known.

Tested with Arduino Nano and small string of WS2801 LEDs.